### PR TITLE
fix how codec is parsed in CLI

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -44,7 +44,7 @@ parser.add_argument('--max-memory', help='maximum amount of RAM in GB to be used
 parser.add_argument('--max-cores', help='number of cores to be use for CPU mode', dest='cores_count', type=int, default=max(psutil.cpu_count() - 2, 2))
 parser.add_argument('--all-faces', help='swap all faces in frame', dest='all_faces', action='store_true', default=False)
 parser.add_argument('--gpu-threads', help='number of threads for gpu to run in parallel', dest='gpu_threads', type=int, default=4)
-parser.add_argument('--codec', help='libx264 (put 4) ot libx265 (put 5)', dest='codec', type=int, default=4)
+parser.add_argument('--codec', help='video encoder (libx264 or libx265)', dest='codec', default='libx264', choices=['libx264', 'libx265'])
 for name, value in vars(parser.parse_args()).items():
     args[name] = value
 
@@ -263,13 +263,6 @@ def run():
     if args['source_img']:
         args['cli_mode'] = True
         start()
-        quit()
-    if args['codec'] == 4:
-        args['codec'] = "libx264"
-    elif args['codec'] == 5:
-        args['codec'] = "libx265"
-    else:
-        print("wrong codec, please advise the guide")
         quit()
     window = tk.Tk()
     window.geometry("600x700")


### PR DESCRIPTION
`codec` argument isn't well parsed in CLI

this PR should fix this error:

```
Traceback (most recent call last):
File "███/Richard-roop-main/run.py", line 5, in <module>
core.run()
File "███/Richard-roop-main/roop/core.py", line 259, in run
start()
File "███/Richard-roop-main/roop/core.py", line 237, in start
start_processing(exact_fps, target_path)
File "███/Richard-roop-main/roop/core.py", line 101, in start_processing
process_video_gpu(args['source_img'],
File "███/Richard-roop-main/roop/gpu_optimizer.py", line 110, in process_video_gpu
video_proc.run_video_chain(source_video,
File "███/Richard-roop-main/chain_video_processor.py", line 65, in run_video_chain
with FFMPEG_VideoWriter(target_video, (width, height), fps, codec=video_codec, crf=video_crf, audiofile=video_audio) as output_video_ff:
File "███/Richard-roop-main/ffmpeg_writer.py", line 136, in __init__
self.proc = sp.Popen(cmd, **popen_params)
File "██████/lib/python3.10/subprocess.py", line 971, in __init__
self._execute_child(args, executable, preexec_fn, close_fds,
File "██████/lib/python3.10/subprocess.py", line 1796, in _execute_child
self.pid = _posixsubprocess.fork_exec(
TypeError: expected str, bytes or os.PathLike object, not int
```